### PR TITLE
Homework4

### DIFF
--- a/server/src/main/java/ClientHandler.java
+++ b/server/src/main/java/ClientHandler.java
@@ -25,8 +25,8 @@ public class ClientHandler {
             in = new DataInputStream(socket.getInputStream());
             out = new DataOutputStream(socket.getOutputStream());
             System.out.println("Подключился клиент, сокет: " + socket.getRemoteSocketAddress());
-
-            new Thread(() -> {
+            server.service.execute(()->{
+            //new Thread(() -> {
                 try {
                     socket.setSoTimeout(5000); // Таймаут на отключение клиента, если клиент не зарегистрирован
                     //цикл аутентификации
@@ -117,7 +117,8 @@ public class ClientHandler {
                         e.printStackTrace();
                     }
                 }
-            }).start();
+            //}).start();
+            });
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/server/src/main/java/Server.java
+++ b/server/src/main/java/Server.java
@@ -13,11 +13,12 @@ import java.net.Socket;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Scanner;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.*;
 
 public class Server {
     private List<ClientHandler> clients; // Список подключений
     private AuthService authService; //Объект для обработки аудентификации
+    ExecutorService service = Executors.newCachedThreadPool();
 
     public Server() {
         clients = new CopyOnWriteArrayList<>();
@@ -25,7 +26,6 @@ public class Server {
         ServerSocket server = null;
         Socket socket = null;
         final int PORT = 8189;
-
         try {
             server = new ServerSocket(PORT);
             System.out.println("Сервер запустился");
@@ -33,6 +33,8 @@ public class Server {
             while (true) { // Бесконечный цикл в котором создается ClientHandler для нового подключения
                 socket = server.accept(); // !...! Точка ожидания нового подключения
                 new ClientHandler(this, socket); // Выполняется при появление нового подключения
+                System.out.println("Кол-во активных потоков: " + ((ThreadPoolExecutor) service).getPoolSize());
+                System.out.println("Кол-во завершенных потоков: " + ((ThreadPoolExecutor) service).getCompletedTaskCount());
             }
 
         } catch (IOException e) {
@@ -48,6 +50,7 @@ public class Server {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+            service.shutdown();
         }
     }
 


### PR DESCRIPTION
Задание выполнено. Правда, я не нашел метод в ThreadPoolExecutor который бы выводил кол-во потоков, выделенных в памяти (когда еще 60 секунд после закрытия потока еще была бы выделена память) - перебрал все методы get*. 

Насчет моего мнения - я использовал newCachedThreadPool так как считаю правильно было заменить Thread в ClientHandler, чтобы при дисконнекте клиента высвобождалась память от закрытого потока. Другие фабрики потоков (с фиксированным количеством потоков), насколько я понимаю, привели бы к тому, что к серверу не смогли бы подключится более заданного количества клиентов, пока кто-то из ранее подключенных не отсоединиться. Возможно такой вариант и стоит рассмотреть при ограниченных ресурсах сервера, хотя можно и через выбранный мной фабрику можно сравнивать getPoolSize() с максимально-допустимым количеством подсоединений и обрабатывать эту ситуация: ненадолго подключать клиента, создавая поток, и выдавать ему, что к серверу подключено слишком много клиентов.  